### PR TITLE
Update build outputs to build/lib and build/include

### DIFF
--- a/buildDependencies.sh
+++ b/buildDependencies.sh
@@ -24,7 +24,10 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # ---------------------------------------------------------
 # Default Values
 # ---------------------------------------------------------
-DOWNLOAD_DIR="${SCRIPT_DIR}/lib"
+BUILD_ROOT="${SCRIPT_DIR}/build"
+DOWNLOAD_DIR="${BUILD_ROOT}/dependencies"
+INCLUDE_OUTPUT_DIR="${BUILD_ROOT}/include"
+DEPENDENCY_INCLUDE_DIR="${INCLUDE_OUTPUT_DIR}/dependencies"
 TOOLCHAIN_FILE=null
 
 # iOS Toolchain
@@ -128,7 +131,7 @@ OUTPUT_DIR="$(cd "$OUTPUT_DIR" && pwd)"
 mkdir -p "$DOWNLOAD_DIR"
 DOWNLOAD_DIR="$(cd "$DOWNLOAD_DIR" && pwd)"
 
-mkdir -p "${DOWNLOAD_DIR}/include"
+mkdir -p "$DEPENDENCY_INCLUDE_DIR"
 # ---------------------------------------------------------
 # Toolchain configuration based on the requested output
 # ---------------------------------------------------------
@@ -325,7 +328,7 @@ build_zlib() {
   fi
   make clean > /dev/null
   make static
-  cp "zlib.h" "zconf.h" "${DOWNLOAD_DIR}/include/"
+  cp "zlib.h" "zconf.h" "${DEPENDENCY_INCLUDE_DIR}/"
   cp "libz.a" "${OUTPUT_DIR}/"
   popd > /dev/null
   echo "✅ Finished building libz.a into ${OUTPUT_DIR}!"
@@ -341,7 +344,7 @@ build_bzip2() {
   pushd "${src_dir}" > /dev/null
   make clean > /dev/null
   make CFLAGS="${EXTRA_CFLAGS} -fPIC -O2 -g -D_FILE_OFFSET_BITS=64" libbz2.a > /dev/null
-  cp "bzlib.h" "${DOWNLOAD_DIR}/include/"
+  cp "bzlib.h" "${DEPENDENCY_INCLUDE_DIR}/"
   cp "libbz2.a" "${OUTPUT_DIR}/"
   popd > /dev/null
   echo "✅ Finished building libbz2.a into ${OUTPUT_DIR}!"
@@ -358,7 +361,7 @@ build_zstd() {
   make clean > /dev/null
   CFLAGS="${EXTRA_CFLAGS} -fPIC -O2" make libzstd.a > /dev/null
   popd > /dev/null
-  cp "${src_dir}/lib/zstd.h" "${src_dir}/lib/zdict.h" "${DOWNLOAD_DIR}/include/"
+  cp "${src_dir}/lib/zstd.h" "${src_dir}/lib/zdict.h" "${DEPENDENCY_INCLUDE_DIR}/"
   cp "${src_dir}/lib/libzstd.a" "${OUTPUT_DIR}/"
   echo "✅ Finished building libzstd.a into ${OUTPUT_DIR}!"
 }
@@ -410,7 +413,7 @@ build_snappy() {
   make clean > /dev/null
   CXXFLAGS="${EXTRA_CXXFLAGS} -fPIC -O2" CFLAGS="${EXTRA_CFLAGS} -fPIC -O2" make ${SNAPPY_MAKE_TARGET} > /dev/null
   cmake --install . --prefix "${install_prefix}" > /dev/null
-  cp "snappy.h" "snappy-stubs-public.h" "${DOWNLOAD_DIR}/include/"
+  cp "snappy.h" "snappy-stubs-public.h" "${DEPENDENCY_INCLUDE_DIR}/"
   cp "libsnappy.a" "${OUTPUT_DIR}/"
   popd > /dev/null
   echo "✅ Finished building libsnappy.a into ${OUTPUT_DIR}!"
@@ -435,7 +438,7 @@ build_lz4() {
   fi
 
   TARGET_OS=$TARGET_OS CFLAGS="${EXTRA_CFLAGS} -fPIC -O2" LDFLAGS="${EXTRA_LDFLAGS}" make liblz4.a > /dev/null
-  cp "lz4.h" "lz4hc.h" "${DOWNLOAD_DIR}/include/"
+  cp "lz4.h" "lz4hc.h" "${DEPENDENCY_INCLUDE_DIR}/"
   cp "liblz4.a" "${OUTPUT_DIR}/"
   popd > /dev/null
   echo "✅ Finished building liblz4.a into ${OUTPUT_DIR}!"

--- a/buildRocksdbApple.sh
+++ b/buildRocksdbApple.sh
@@ -118,7 +118,7 @@ fi
 ###############################################################################
 SIM_SUFFIX=$([[ "$SIMULATOR" == true ]] && echo "_simulator" || echo "")
 
-BUILD_DIR="build/${PLATFORM}${SIM_SUFFIX}_${ARCH}"
+BUILD_DIR="../build/lib/${PLATFORM}${SIM_SUFFIX}_${ARCH}"
 
 ###############################################################################
 # Common compiler & linker flags
@@ -127,7 +127,7 @@ EXTRA_FLAGS=""
 EXTRA_FLAGS+=" $MIN_FLAG"
 EXTRA_FLAGS+=" $TARGET_TRIPLE"
 EXTRA_FLAGS+=" -isysroot $SDK_PATH"
-EXTRA_FLAGS+=" -I../lib/include"
+EXTRA_FLAGS+=" -I../build/include -I../build/include/dependencies"
 EXTRA_FLAGS+=" -DZLIB -DBZIP2 -DSNAPPY -DLZ4 -DZSTD"
 
 LD_FLAGS="-lbz2 -lz -lz4 -lsnappy"
@@ -136,6 +136,8 @@ LD_FLAGS="-lbz2 -lz -lz4 -lsnappy"
 # Move into rocksdb directory
 ###############################################################################
 cd "rocksdb" || { echo "Could not enter rocksdb directory"; exit 1; }
+
+mkdir -p "$BUILD_DIR"
 
 ###############################################################################
 # Function to check the build output

--- a/buildRocksdbMinGW.sh
+++ b/buildRocksdbMinGW.sh
@@ -26,14 +26,14 @@ case "$ARCH" in
     CXX="x86_64-w64-mingw32-g++"
     CMAKE_TOOLCHAIN_FLAGS="-DCMAKE_SYSTEM_NAME=Windows -DCMAKE_SYSTEM_PROCESSOR=x86_64"
     EXTRA_FLAGS="-march=x86-64"
-    OBJ_DIR="rocksdb/build/mingw_x86_64"
+    OBJ_DIR="build/lib/mingw_x86_64"
     ;;
   i686)
     CC="i686-w64-mingw32-gcc"
     CXX="i686-w64-mingw32-g++"
     CMAKE_TOOLCHAIN_FLAGS="-DCMAKE_SYSTEM_NAME=Windows -DCMAKE_SYSTEM_PROCESSOR=i686"
     EXTRA_FLAGS="-march=i686"
-    OBJ_DIR="rocksdb/build/mingw_i686"
+    OBJ_DIR="build/lib/mingw_i686"
     ;;
   *)
     echo "Unsupported ARCH: $ARCH"
@@ -70,6 +70,11 @@ fi
 # Check if the output library already exists
 if [ -f "${OBJ_DIR}/librocksdb.a" ]; then
   echo "** BUILD SKIPPED: ${OBJ_DIR}/librocksdb.a already exists **"
+  exit 0
+fi
+
+if [ -f "${OBJ_DIR}/rocksdb-build/librocksdb.a" ]; then
+  echo "** BUILD SKIPPED: ${OBJ_DIR}/rocksdb-build/librocksdb.a already exists **"
   exit 0
 fi
 


### PR DESCRIPTION
## Summary
- build third-party dependencies and rocksdb static libraries under build/lib/<target>
- copy dependency headers into build/include and stage RocksDB headers there before packaging
- adjust Gradle packaging to archive the new include and lib directories

## Testing
- ./gradlew tasks

------
https://chatgpt.com/codex/tasks/task_e_68ce9ee9546c8321a1d3d37722e89322