### PR TITLE
Use Ubuntu 18.04 container for Linux builds

### DIFF
--- a/.github/workflows/build-rocksdb.yml
+++ b/.github/workflows/build-rocksdb.yml
@@ -12,7 +12,7 @@ jobs:
   linux-x64:
     name: Linux x86_64
     runs-on: ubuntu-latest
-    container: ubuntu:20.04
+    container: ubuntu:18.04
     steps:
       - name: Prepare apt (install git for checkout)
         run: |
@@ -42,7 +42,7 @@ jobs:
   linux-arm64:
     name: Linux ARM64
     runs-on: ubuntu-24.04-arm
-    container: ubuntu:20.04
+    container: ubuntu:18.04
     steps:
       - name: Prepare apt (install git for checkout)
         run: |


### PR DESCRIPTION
## Summary
- run the Linux x86_64 and ARM64 GitHub Actions jobs inside ubuntu:18.04 containers to link against glibc 2.27

## Testing
- not run (CI configuration change only)


------
https://chatgpt.com/codex/tasks/task_e_68d30f77104083219b47eedee62462d6