### PR TITLE
Fix Kotlin Native toolchain extraction on Windows

### DIFF
--- a/.github/workflows/build-rocksdb.yml
+++ b/.github/workflows/build-rocksdb.yml
@@ -140,34 +140,38 @@ jobs:
       - name: Install build dependencies
         run: |
           choco install -y make ninja
-      - name: Install LLVM MinGW toolchain
+      - name: Install Kotlin/Native MinGW GCC toolchain
+        env:
+          KONAN_VERSION: 2.2.20
         run: |
           set -euo pipefail
-          LLVM_MINGW_VERSION=20250910
-          LLVM_MINGW_DIST=llvm-mingw-${LLVM_MINGW_VERSION}-ucrt-x86_64
-          ARCHIVE_NAME="${LLVM_MINGW_DIST}.zip"
-          ARCHIVE_PATH="$PWD/${ARCHIVE_NAME}"
-          curl -sSL -o "$ARCHIVE_PATH" "https://github.com/mstorsjo/llvm-mingw/releases/download/${LLVM_MINGW_VERSION}/${ARCHIVE_NAME}"
           TOOLCHAIN_DIR="$PWD/toolchains"
           mkdir -p "$TOOLCHAIN_DIR"
-          rm -rf "$TOOLCHAIN_DIR/${LLVM_MINGW_DIST}"
-          python - "$ARCHIVE_PATH" "$TOOLCHAIN_DIR" <<'PY'
-          import pathlib, sys, zipfile
-
-          archive = pathlib.Path(sys.argv[1])
-          dest = pathlib.Path(sys.argv[2])
-          dest.mkdir(parents=True, exist_ok=True)
-          with zipfile.ZipFile(archive) as zf:
-              zf.extractall(dest)
-          PY
+          ARCHIVE_NAME="kotlin-native-prebuilt-windows-x86_64-${KONAN_VERSION}.zip"
+          ARCHIVE_PATH="$TOOLCHAIN_DIR/${ARCHIVE_NAME}"
+          ARCHIVE_URL="https://github.com/JetBrains/kotlin/releases/download/v${KONAN_VERSION}/${ARCHIVE_NAME}"
+          echo "Downloading Kotlin/Native toolchain ${KONAN_VERSION} from ${ARCHIVE_URL}"
+          curl --fail --location --silent --show-error "$ARCHIVE_URL" --output "$ARCHIVE_PATH"
+          tar -xf "$ARCHIVE_PATH" -C "$TOOLCHAIN_DIR"
           rm -f "$ARCHIVE_PATH"
-          LLVM_MINGW_ROOT="$TOOLCHAIN_DIR/${LLVM_MINGW_DIST}"
-          if [[ ! -d "$LLVM_MINGW_ROOT" ]]; then
-            echo "Expected toolchain directory $LLVM_MINGW_ROOT not found" >&2
+          KONAN_ROOT="$TOOLCHAIN_DIR/kotlin-native-prebuilt-windows-x86_64-${KONAN_VERSION}"
+          TOOLCHAIN_ROOT="$KONAN_ROOT/dependencies/msys2-mingw-w64-x86_64-2"
+          if [[ ! -d "$TOOLCHAIN_ROOT" ]]; then
+            echo "Expected Kotlin/Native MinGW toolchain at $TOOLCHAIN_ROOT" >&2
+            ls -R "$KONAN_ROOT" >&2
             exit 1
           fi
-          echo "LLVM_MINGW_ROOT=$LLVM_MINGW_ROOT" >> "$GITHUB_ENV"
-          echo "$LLVM_MINGW_ROOT/bin" >> "$GITHUB_PATH"
+          GCC_MINGW_PREFIX="$TOOLCHAIN_ROOT/mingw64"
+          if [[ ! -d "$GCC_MINGW_PREFIX/bin" ]]; then
+            echo "Expected MinGW bin directory at $GCC_MINGW_PREFIX/bin" >&2
+            exit 1
+          fi
+          echo "LLVM_MINGW_ROOT=$GCC_MINGW_PREFIX" >> "$GITHUB_ENV"
+          echo "MINGW_GCC_SYSROOT=$GCC_MINGW_PREFIX" >> "$GITHUB_ENV"
+          echo "$GCC_MINGW_PREFIX/bin" >> "$GITHUB_PATH"
+          if [[ -d "$TOOLCHAIN_ROOT/usr/bin" ]]; then
+            echo "$TOOLCHAIN_ROOT/usr/bin" >> "$GITHUB_PATH"
+          fi
       - name: Build Windows MinGW package
         run: ./build.sh mingwX64
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/build-rocksdb.yml
+++ b/.github/workflows/build-rocksdb.yml
@@ -152,7 +152,11 @@ jobs:
           ARCHIVE_URL="https://github.com/JetBrains/kotlin/releases/download/v${KONAN_VERSION}/${ARCHIVE_NAME}"
           echo "Downloading Kotlin/Native toolchain ${KONAN_VERSION} from ${ARCHIVE_URL}"
           curl --fail --location --silent --show-error "$ARCHIVE_URL" --output "$ARCHIVE_PATH"
-          tar -xf "$ARCHIVE_PATH" -C "$TOOLCHAIN_DIR"
+          if command -v unzip >/dev/null 2>&1; then
+            unzip -q "$ARCHIVE_PATH" -d "$TOOLCHAIN_DIR"
+          else
+            powershell.exe -NoLogo -NoProfile -Command "Expand-Archive -Path '${ARCHIVE_PATH}' -DestinationPath '${TOOLCHAIN_DIR}' -Force"
+          fi
           rm -f "$ARCHIVE_PATH"
           KONAN_ROOT="$TOOLCHAIN_DIR/kotlin-native-prebuilt-windows-x86_64-${KONAN_VERSION}"
           TOOLCHAIN_ROOT="$KONAN_ROOT/dependencies/msys2-mingw-w64-x86_64-2"
@@ -203,15 +207,11 @@ jobs:
           TOOLCHAIN_DIR="$PWD/toolchains"
           mkdir -p "$TOOLCHAIN_DIR"
           rm -rf "$TOOLCHAIN_DIR/${LLVM_MINGW_DIST}"
-          python - "$ARCHIVE_PATH" "$TOOLCHAIN_DIR" <<'PY'
-          import pathlib, sys, zipfile
-
-          archive = pathlib.Path(sys.argv[1])
-          dest = pathlib.Path(sys.argv[2])
-          dest.mkdir(parents=True, exist_ok=True)
-          with zipfile.ZipFile(archive) as zf:
-              zf.extractall(dest)
-          PY
+          if command -v unzip >/dev/null 2>&1; then
+            unzip -q "$ARCHIVE_PATH" -d "$TOOLCHAIN_DIR"
+          else
+            powershell.exe -NoLogo -NoProfile -Command "Expand-Archive -Path '${ARCHIVE_PATH}' -DestinationPath '${TOOLCHAIN_DIR}' -Force"
+          fi
           rm -f "$ARCHIVE_PATH"
           LLVM_MINGW_ROOT="$TOOLCHAIN_DIR/${LLVM_MINGW_DIST}"
           if [[ ! -d "$LLVM_MINGW_ROOT" ]]; then


### PR DESCRIPTION
## Summary
- ensure the Windows MinGW ARM64 workflow uses the same unzip/Expand-Archive fallback as x64

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d5b9b91ce48321ae78562310e2c047