### PR TITLE
Align Windows builds with Kotlin/Native MinGW toolchain

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,14 @@ The archives are staged under `build/archives/` during a build and can be publis
 - Similarly, simulator builds for iOS, watchOS, and tvOS are arm64-only—aside from the macOS x86_64 build, there are no simulator x86_64 variants because developers are expected to be on Apple Silicon hardware five years after its introduction.
 - The `watchos-arm64` archive labelled above uses the `arm64_32` ABI (64-bit registers with 32-bit pointers) because that remains the deployment baseline for physical watches.
 
+### Windows (MinGW) builds and Kotlin/Native
+
+Kotlin/Native ships a complete MinGW-w64 GCC toolchain under `~/.konan/dependencies/msys2-mingw-w64-<arch>-2` on Windows hosts. Those bundles already contain the GCC runtime (`libstdc++`, `libsupc++`, `libgcc`, `libwinpthread`, …), which is what Kotlin/Native links against. To ensure the RocksDB archives remain compatible with that runtime:
+
+1. Install or unpack a MinGW toolchain that matches Kotlin/Native (for example, reuse the contents of `~/.konan/dependencies/msys2-mingw-w64-x86_64-2`). If you keep the toolchain elsewhere, set `KONAN_MINGW_ROOT` to the directory that contains the `mingw64/`, `mingw32/`, or `aarch64/` subfolders before invoking `build.sh`.
+2. The build scripts will automatically add the corresponding `bin/` directory to `PATH` and pick up `x86_64-w64-mingw32-gcc`, `i686-w64-mingw32-gcc`, or `aarch64-w64-mingw32-gcc` for the Windows targets. No `-stdlib=libc++` flags are injected, so RocksDB links exclusively against libstdc++.
+3. Archives assembled from MinGW builds only include `librocksdb.a`, `libsnappy.a`, `libzstd.a`, `libbz2.a`, `libz.a`, and `liblz4.a`. Kotlin/Native's own toolchain continues to provide the GCC runtime when consumers link their applications.
+
 ## Usage examples
 - List available build configurations:
   ```bash

--- a/buildDependencies.sh
+++ b/buildDependencies.sh
@@ -255,6 +255,7 @@ elif [[ "$OUTPUT_DIR" == *macos_arm64* ]]; then
   export MACOSX_DEPLOYMENT_TARGET="${MACOSX_DEPLOYMENT_TARGET:-11.0}"
 elif [[ "$OUTPUT_DIR" == *mingw_x86_64* ]]; then
   TOOLCHAIN_TRIPLE="x86_64-w64-mingw32"
+  build_common::maybe_add_konan_mingw_to_path "$TOOLCHAIN_TRIPLE"
   if command -v "${TOOLCHAIN_TRIPLE}-gcc" >/dev/null 2>&1; then
     export CC="${TOOLCHAIN_TRIPLE}-gcc"
     export CXX="${TOOLCHAIN_TRIPLE}-g++"
@@ -309,6 +310,7 @@ elif [[ "$OUTPUT_DIR" == *mingw_x86_64* ]]; then
   fi
 elif [[ "$OUTPUT_DIR" == *mingw_arm64* ]]; then
   TOOLCHAIN_TRIPLE="aarch64-w64-mingw32"
+  build_common::maybe_add_konan_mingw_to_path "$TOOLCHAIN_TRIPLE"
   if command -v "${TOOLCHAIN_TRIPLE}-gcc" >/dev/null 2>&1; then
     export CC="${TOOLCHAIN_TRIPLE}-gcc"
     export CXX="${TOOLCHAIN_TRIPLE}-g++"

--- a/buildRocksdbMinGW.sh
+++ b/buildRocksdbMinGW.sh
@@ -38,6 +38,7 @@ fi
 case "$ARCH" in
   x86_64)
     TOOLCHAIN_TRIPLE="x86_64-w64-mingw32"
+    build_common::maybe_add_konan_mingw_to_path "$TOOLCHAIN_TRIPLE"
     CC="${TOOLCHAIN_TRIPLE}-gcc"
     CXX="${TOOLCHAIN_TRIPLE}-g++"
     cmake_toolchain_flags=(
@@ -50,6 +51,7 @@ case "$ARCH" in
     ;;
   i686)
     TOOLCHAIN_TRIPLE="i686-w64-mingw32"
+    build_common::maybe_add_konan_mingw_to_path "$TOOLCHAIN_TRIPLE"
     CC="${TOOLCHAIN_TRIPLE}-gcc"
     CXX="${TOOLCHAIN_TRIPLE}-g++"
     cmake_toolchain_flags=(
@@ -62,6 +64,7 @@ case "$ARCH" in
     ;;
   arm64|aarch64)
     TOOLCHAIN_TRIPLE="aarch64-w64-mingw32"
+    build_common::maybe_add_konan_mingw_to_path "$TOOLCHAIN_TRIPLE"
     if command -v "${TOOLCHAIN_TRIPLE}-gcc" >/dev/null 2>&1; then
       CC="${TOOLCHAIN_TRIPLE}-gcc"
       CXX="${TOOLCHAIN_TRIPLE}-g++"


### PR DESCRIPTION
## Summary
- auto-detect Kotlin/Native MinGW toolchains and add their bin directories to PATH
- route Windows RocksDB and dependency builds through the GCC toolchain for every architecture and restrict packaged libs to RocksDB and codecs
- document the Kotlin/Native MinGW setup in the README for Windows builders

## Testing
- ./build.sh --list

------
https://chatgpt.com/codex/tasks/task_e_68d672b3b9608321b746f0022ae0828e