### PR TITLE
Ensure MinGW builds use GNU C++ runtime

### DIFF
--- a/build-rocksdb-common.sh
+++ b/build-rocksdb-common.sh
@@ -23,6 +23,31 @@ build_common::append_unique_flag() {
   printf -v "$var_name" '%s' "$current"
 }
 
+build_common::compiler_is_clang() {
+  local compiler="$1"
+  if [[ -z "$compiler" ]]; then
+    return 1
+  fi
+
+  if [[ "$compiler" == *"clang"* ]]; then
+    return 0
+  fi
+
+  local compiler_path
+  compiler_path="$(command -v "$compiler" 2>/dev/null || true)"
+  if [[ -z "$compiler_path" ]]; then
+    return 1
+  fi
+
+  local version_output
+  version_output="$("$compiler_path" --version 2>/dev/null || true)"
+  if [[ "$version_output" == *"clang"* || "$version_output" == *"LLVM"* ]]; then
+    return 0
+  fi
+
+  return 1
+}
+
 build_common::is_windows_host() {
   case "$(uname -s 2>/dev/null || echo unknown)" in
     MINGW*|MSYS*|CYGWIN*) return 0 ;;

--- a/buildDependencies.sh
+++ b/buildDependencies.sh
@@ -274,7 +274,7 @@ elif [[ "$OUTPUT_DIR" == *mingw_x86_64* ]]; then
   build_common::ensure_mingw_environment "${TOOLCHAIN_TRIPLE}" "${CC:-}"
   export MINGW_TRIPLE="${TOOLCHAIN_TRIPLE}"
 
-  if [[ "${CC}" == *"clang"* ]]; then
+  if build_common::compiler_is_clang "${CC}"; then
     build_common::append_unique_flag EXTRA_CFLAGS "--target=${TOOLCHAIN_TRIPLE}"
     build_common::append_unique_flag EXTRA_CXXFLAGS "--target=${TOOLCHAIN_TRIPLE}"
     build_common::append_unique_flag EXTRA_CXXFLAGS "-stdlib=libstdc++"
@@ -282,7 +282,7 @@ elif [[ "$OUTPUT_DIR" == *mingw_x86_64* ]]; then
   if [[ -n "${MINGW_SYSROOT:-}" ]]; then
     build_common::apply_mingw_sysroot_flags "${TOOLCHAIN_TRIPLE}" EXTRA_CFLAGS EXTRA_CXXFLAGS EXTRA_CMAKEFLAGS
   fi
-  if [[ "${CC}" == *"clang"* && -n "${MINGW_GCC_TOOLCHAIN_ROOT:-}" ]]; then
+  if build_common::compiler_is_clang "${CC}" && [[ -n "${MINGW_GCC_TOOLCHAIN_ROOT:-}" ]]; then
     build_common::append_unique_flag EXTRA_CFLAGS "--gcc-toolchain=${MINGW_GCC_TOOLCHAIN_ROOT}"
     build_common::append_unique_flag EXTRA_CXXFLAGS "--gcc-toolchain=${MINGW_GCC_TOOLCHAIN_ROOT}"
   fi
@@ -359,7 +359,7 @@ elif [[ "$OUTPUT_DIR" == *mingw_arm64* ]]; then
   build_common::ensure_mingw_environment "${TOOLCHAIN_TRIPLE}" "${CC:-}"
   export MINGW_TRIPLE="${TOOLCHAIN_TRIPLE}"
 
-  if [[ "${CC}" == *"clang"* ]]; then
+  if build_common::compiler_is_clang "${CC}"; then
     build_common::append_unique_flag EXTRA_CFLAGS "--target=${TOOLCHAIN_TRIPLE}"
     build_common::append_unique_flag EXTRA_CXXFLAGS "--target=${TOOLCHAIN_TRIPLE}"
     build_common::append_unique_flag EXTRA_CXXFLAGS "-stdlib=libstdc++"
@@ -367,7 +367,7 @@ elif [[ "$OUTPUT_DIR" == *mingw_arm64* ]]; then
   if [[ -n "${MINGW_SYSROOT:-}" ]]; then
     build_common::apply_mingw_sysroot_flags "${TOOLCHAIN_TRIPLE}" EXTRA_CFLAGS EXTRA_CXXFLAGS EXTRA_CMAKEFLAGS
   fi
-  if [[ "${CC}" == *"clang"* && -n "${MINGW_GCC_TOOLCHAIN_ROOT:-}" ]]; then
+  if build_common::compiler_is_clang "${CC}" && [[ -n "${MINGW_GCC_TOOLCHAIN_ROOT:-}" ]]; then
     build_common::append_unique_flag EXTRA_CFLAGS "--gcc-toolchain=${MINGW_GCC_TOOLCHAIN_ROOT}"
     build_common::append_unique_flag EXTRA_CXXFLAGS "--gcc-toolchain=${MINGW_GCC_TOOLCHAIN_ROOT}"
   fi

--- a/buildDependencies.sh
+++ b/buildDependencies.sh
@@ -277,12 +277,28 @@ elif [[ "$OUTPUT_DIR" == *mingw_x86_64* ]]; then
   if [[ "${CC}" == *"clang"* ]]; then
     build_common::append_unique_flag EXTRA_CFLAGS "--target=${TOOLCHAIN_TRIPLE}"
     build_common::append_unique_flag EXTRA_CXXFLAGS "--target=${TOOLCHAIN_TRIPLE}"
+    build_common::append_unique_flag EXTRA_CXXFLAGS "-stdlib=libstdc++"
   fi
   if [[ -n "${MINGW_SYSROOT:-}" ]]; then
     build_common::apply_mingw_sysroot_flags "${TOOLCHAIN_TRIPLE}" EXTRA_CFLAGS EXTRA_CXXFLAGS EXTRA_CMAKEFLAGS
   fi
   build_common::append_unique_flag EXTRA_CMAKEFLAGS "-DCMAKE_C_COMPILER_TARGET=${TOOLCHAIN_TRIPLE}"
   build_common::append_unique_flag EXTRA_CMAKEFLAGS "-DCMAKE_CXX_COMPILER_TARGET=${TOOLCHAIN_TRIPLE}"
+  build_common::append_unique_flag EXTRA_CMAKEFLAGS "-DCMAKE_C_STANDARD_LIBRARIES=-lgcc;-lwinpthread"
+  build_common::append_unique_flag EXTRA_CMAKEFLAGS "-DCMAKE_CXX_STANDARD_LIBRARIES=-lstdc++;-lsupc++;-lgcc;-lwinpthread"
+
+  for mingw_runtime_lib in -lstdc++ -lsupc++ -lgcc -lwinpthread; do
+    case " ${EXTRA_LDFLAGS} " in
+      *" ${mingw_runtime_lib} "*) ;;
+      *)
+        if [[ -n "${EXTRA_LDFLAGS}" ]]; then
+          EXTRA_LDFLAGS+=" ${mingw_runtime_lib}"
+        else
+          EXTRA_LDFLAGS="${mingw_runtime_lib}"
+        fi
+        ;;
+    esac
+  done
 
   if command -v "${TOOLCHAIN_TRIPLE}-ar" >/dev/null 2>&1; then
     export AR="${TOOLCHAIN_TRIPLE}-ar"
@@ -331,12 +347,28 @@ elif [[ "$OUTPUT_DIR" == *mingw_arm64* ]]; then
   if [[ "${CC}" == *"clang"* ]]; then
     build_common::append_unique_flag EXTRA_CFLAGS "--target=${TOOLCHAIN_TRIPLE}"
     build_common::append_unique_flag EXTRA_CXXFLAGS "--target=${TOOLCHAIN_TRIPLE}"
+    build_common::append_unique_flag EXTRA_CXXFLAGS "-stdlib=libstdc++"
   fi
   if [[ -n "${MINGW_SYSROOT:-}" ]]; then
     build_common::apply_mingw_sysroot_flags "${TOOLCHAIN_TRIPLE}" EXTRA_CFLAGS EXTRA_CXXFLAGS EXTRA_CMAKEFLAGS
   fi
   build_common::append_unique_flag EXTRA_CMAKEFLAGS "-DCMAKE_C_COMPILER_TARGET=${TOOLCHAIN_TRIPLE}"
   build_common::append_unique_flag EXTRA_CMAKEFLAGS "-DCMAKE_CXX_COMPILER_TARGET=${TOOLCHAIN_TRIPLE}"
+  build_common::append_unique_flag EXTRA_CMAKEFLAGS "-DCMAKE_C_STANDARD_LIBRARIES=-lgcc;-lwinpthread"
+  build_common::append_unique_flag EXTRA_CMAKEFLAGS "-DCMAKE_CXX_STANDARD_LIBRARIES=-lstdc++;-lsupc++;-lgcc;-lwinpthread"
+
+  for mingw_runtime_lib in -lstdc++ -lsupc++ -lgcc -lwinpthread; do
+    case " ${EXTRA_LDFLAGS} " in
+      *" ${mingw_runtime_lib} "*) ;;
+      *)
+        if [[ -n "${EXTRA_LDFLAGS}" ]]; then
+          EXTRA_LDFLAGS+=" ${mingw_runtime_lib}"
+        else
+          EXTRA_LDFLAGS="${mingw_runtime_lib}"
+        fi
+        ;;
+    esac
+  done
 
   if command -v "${TOOLCHAIN_TRIPLE}-ar" >/dev/null 2>&1; then
     export AR="${TOOLCHAIN_TRIPLE}-ar"

--- a/buildDependencies.sh
+++ b/buildDependencies.sh
@@ -282,6 +282,21 @@ elif [[ "$OUTPUT_DIR" == *mingw_x86_64* ]]; then
   if [[ -n "${MINGW_SYSROOT:-}" ]]; then
     build_common::apply_mingw_sysroot_flags "${TOOLCHAIN_TRIPLE}" EXTRA_CFLAGS EXTRA_CXXFLAGS EXTRA_CMAKEFLAGS
   fi
+  if [[ "${CC}" == *"clang"* && -n "${MINGW_GCC_TOOLCHAIN_ROOT:-}" ]]; then
+    build_common::append_unique_flag EXTRA_CFLAGS "--gcc-toolchain=${MINGW_GCC_TOOLCHAIN_ROOT}"
+    build_common::append_unique_flag EXTRA_CXXFLAGS "--gcc-toolchain=${MINGW_GCC_TOOLCHAIN_ROOT}"
+  fi
+  if [[ -n "${MINGW_LIBRARY_SEARCH_FLAGS:-}" ]]; then
+    if [[ -n "${EXTRA_LDFLAGS}" ]]; then
+      EXTRA_LDFLAGS+=" ${MINGW_LIBRARY_SEARCH_FLAGS}"
+    else
+      EXTRA_LDFLAGS="${MINGW_LIBRARY_SEARCH_FLAGS}"
+    fi
+  fi
+  if [[ -n "${MINGW_LIBRARY_DIRECTORIES:-}" ]]; then
+    build_common::append_unique_flag EXTRA_CMAKEFLAGS "-DCMAKE_SYSTEM_LIBRARY_PATH=${MINGW_LIBRARY_DIRECTORIES}"
+    build_common::append_unique_flag EXTRA_CMAKEFLAGS "-DCMAKE_LIBRARY_PATH=${MINGW_LIBRARY_DIRECTORIES}"
+  fi
   build_common::append_unique_flag EXTRA_CMAKEFLAGS "-DCMAKE_C_COMPILER_TARGET=${TOOLCHAIN_TRIPLE}"
   build_common::append_unique_flag EXTRA_CMAKEFLAGS "-DCMAKE_CXX_COMPILER_TARGET=${TOOLCHAIN_TRIPLE}"
   build_common::append_unique_flag EXTRA_CMAKEFLAGS "-DCMAKE_C_STANDARD_LIBRARIES=-lgcc;-lwinpthread"
@@ -351,6 +366,21 @@ elif [[ "$OUTPUT_DIR" == *mingw_arm64* ]]; then
   fi
   if [[ -n "${MINGW_SYSROOT:-}" ]]; then
     build_common::apply_mingw_sysroot_flags "${TOOLCHAIN_TRIPLE}" EXTRA_CFLAGS EXTRA_CXXFLAGS EXTRA_CMAKEFLAGS
+  fi
+  if [[ "${CC}" == *"clang"* && -n "${MINGW_GCC_TOOLCHAIN_ROOT:-}" ]]; then
+    build_common::append_unique_flag EXTRA_CFLAGS "--gcc-toolchain=${MINGW_GCC_TOOLCHAIN_ROOT}"
+    build_common::append_unique_flag EXTRA_CXXFLAGS "--gcc-toolchain=${MINGW_GCC_TOOLCHAIN_ROOT}"
+  fi
+  if [[ -n "${MINGW_LIBRARY_SEARCH_FLAGS:-}" ]]; then
+    if [[ -n "${EXTRA_LDFLAGS}" ]]; then
+      EXTRA_LDFLAGS+=" ${MINGW_LIBRARY_SEARCH_FLAGS}"
+    else
+      EXTRA_LDFLAGS="${MINGW_LIBRARY_SEARCH_FLAGS}"
+    fi
+  fi
+  if [[ -n "${MINGW_LIBRARY_DIRECTORIES:-}" ]]; then
+    build_common::append_unique_flag EXTRA_CMAKEFLAGS "-DCMAKE_SYSTEM_LIBRARY_PATH=${MINGW_LIBRARY_DIRECTORIES}"
+    build_common::append_unique_flag EXTRA_CMAKEFLAGS "-DCMAKE_LIBRARY_PATH=${MINGW_LIBRARY_DIRECTORIES}"
   fi
   build_common::append_unique_flag EXTRA_CMAKEFLAGS "-DCMAKE_C_COMPILER_TARGET=${TOOLCHAIN_TRIPLE}"
   build_common::append_unique_flag EXTRA_CMAKEFLAGS "-DCMAKE_CXX_COMPILER_TARGET=${TOOLCHAIN_TRIPLE}"

--- a/buildRocksdbMinGW.sh
+++ b/buildRocksdbMinGW.sh
@@ -97,6 +97,7 @@ if [[ -n "${TOOLCHAIN_TRIPLE:-}" ]]; then
   if [[ "${CC}" == *"clang"* ]]; then
     build_common::append_unique_flag EXTRA_C_FLAGS "--target=${TOOLCHAIN_TRIPLE}"
     build_common::append_unique_flag EXTRA_CXX_FLAGS "--target=${TOOLCHAIN_TRIPLE}"
+    build_common::append_unique_flag EXTRA_CXX_FLAGS "-stdlib=libstdc++"
   fi
 
   if [[ -n "${MINGW_SYSROOT:-}" ]]; then
@@ -105,6 +106,8 @@ if [[ -n "${TOOLCHAIN_TRIPLE:-}" ]]; then
 
   build_common::append_unique_array_flag cmake_toolchain_flags "-DCMAKE_C_COMPILER_TARGET=${TOOLCHAIN_TRIPLE}"
   build_common::append_unique_array_flag cmake_toolchain_flags "-DCMAKE_CXX_COMPILER_TARGET=${TOOLCHAIN_TRIPLE}"
+  build_common::append_unique_array_flag cmake_toolchain_flags "-DCMAKE_C_STANDARD_LIBRARIES=-lgcc;-lwinpthread"
+  build_common::append_unique_array_flag cmake_toolchain_flags "-DCMAKE_CXX_STANDARD_LIBRARIES=-lstdc++;-lsupc++;-lgcc;-lwinpthread"
 fi
 
 echo "Building RocksDB for Windows (MinGW) with ARCH=${ARCH}"

--- a/buildRocksdbMinGW.sh
+++ b/buildRocksdbMinGW.sh
@@ -102,6 +102,14 @@ if [[ -n "${TOOLCHAIN_TRIPLE:-}" ]]; then
 
   if [[ -n "${MINGW_SYSROOT:-}" ]]; then
     build_common::apply_mingw_sysroot_flags "${TOOLCHAIN_TRIPLE}" EXTRA_C_FLAGS EXTRA_CXX_FLAGS "" cmake_toolchain_flags
+    if [[ "${CC}" == *"clang"* && -n "${MINGW_GCC_TOOLCHAIN_ROOT:-}" ]]; then
+      build_common::append_unique_flag EXTRA_C_FLAGS "--gcc-toolchain=${MINGW_GCC_TOOLCHAIN_ROOT}"
+      build_common::append_unique_flag EXTRA_CXX_FLAGS "--gcc-toolchain=${MINGW_GCC_TOOLCHAIN_ROOT}"
+    fi
+    if [[ -n "${MINGW_LIBRARY_DIRECTORIES:-}" ]]; then
+      build_common::append_unique_array_flag cmake_toolchain_flags "-DCMAKE_SYSTEM_LIBRARY_PATH=${MINGW_LIBRARY_DIRECTORIES}"
+      build_common::append_unique_array_flag cmake_toolchain_flags "-DCMAKE_LIBRARY_PATH=${MINGW_LIBRARY_DIRECTORIES}"
+    fi
   fi
 
   build_common::append_unique_array_flag cmake_toolchain_flags "-DCMAKE_C_COMPILER_TARGET=${TOOLCHAIN_TRIPLE}"


### PR DESCRIPTION
## Summary
- force MinGW builds that fall back to clang to use libstdc++ headers and libraries
- add explicit GNU runtime libraries to MinGW dependency builds and CMake configuration
- prefer libstdc++ include directories over libc++ when discovering MinGW sysroot paths

## Testing
- bash -n buildRocksdbMinGW.sh buildDependencies.sh build-rocksdb-common.sh

------
https://chatgpt.com/codex/tasks/task_e_68d6752663108321bd0c5afebaa28f46