### PR TITLE
Broaden AVX-512 guard for MinGW GCC

### DIFF
--- a/.github/workflows/build-rocksdb.yml
+++ b/.github/workflows/build-rocksdb.yml
@@ -140,25 +140,27 @@ jobs:
       - name: Install build dependencies
         run: |
           choco install -y make ninja
-      - name: Install MinGW-w64 GCC toolchain
+      - name: Set up Java for Kotlin/Native dependencies
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "21"
+      - name: Install Kotlin/Native LLVM MinGW toolchain
         run: |
           set -euo pipefail
-          choco install -y mingw --version=9.4.0
-          DEFAULT_ROOT="C:/ProgramData/mingw64/mingw64"
-          ALT_ROOT="C:/ProgramData/chocolatey/lib/mingw/tools/install/mingw64"
-          if [[ -n "${MINGW_ROOT:-}" && -d "${MINGW_ROOT}/bin" ]]; then
-            TOOLCHAIN_ROOT="$MINGW_ROOT"
-          elif [[ -d "${DEFAULT_ROOT}/bin" ]]; then
-            TOOLCHAIN_ROOT="$DEFAULT_ROOT"
-          elif [[ -d "${ALT_ROOT}/bin" ]]; then
-            TOOLCHAIN_ROOT="$ALT_ROOT"
-          else
-            echo "Failed to locate MinGW installation directory" >&2
+          LLVM_MINGW_ROOT_POSIX=$(bash "$GITHUB_WORKSPACE/scripts/setup-konan-llvm-mingw.sh" \
+            --toolchains-dir="$PWD/toolchains")
+          if [[ -z "$LLVM_MINGW_ROOT_POSIX" ]]; then
+            echo "setup-konan-llvm-mingw.sh did not return a toolchain path" >&2
             exit 1
           fi
-          echo "Using MinGW toolchain at ${TOOLCHAIN_ROOT}"
-          echo "MINGW_ROOT=${TOOLCHAIN_ROOT}" >> "$GITHUB_ENV"
-          echo "${TOOLCHAIN_ROOT}/bin" >> "$GITHUB_PATH"
+          echo "LLVM_MINGW_ROOT=$LLVM_MINGW_ROOT_POSIX" >> "$GITHUB_ENV"
+          if command -v cygpath >/dev/null 2>&1; then
+            WINDOWS_LLVM_MINGW_ROOT=$(cygpath -w "$LLVM_MINGW_ROOT_POSIX")
+          else
+            WINDOWS_LLVM_MINGW_ROOT="$LLVM_MINGW_ROOT_POSIX"
+          fi
+          printf '%s\n' "${WINDOWS_LLVM_MINGW_ROOT}\\bin" >> "$GITHUB_PATH"
       - name: Build Windows MinGW package
         run: ./build.sh mingwX64
       - uses: actions/upload-artifact@v4

--- a/buildDependencies.sh
+++ b/buildDependencies.sh
@@ -255,16 +255,16 @@ elif [[ "$OUTPUT_DIR" == *macos_arm64* ]]; then
   export MACOSX_DEPLOYMENT_TARGET="${MACOSX_DEPLOYMENT_TARGET:-11.0}"
 elif [[ "$OUTPUT_DIR" == *mingw_x86_64* ]]; then
   TOOLCHAIN_TRIPLE="x86_64-w64-mingw32"
-  if command -v "${TOOLCHAIN_TRIPLE}-gcc" >/dev/null 2>&1; then
-    export CC="${TOOLCHAIN_TRIPLE}-gcc"
-    export CXX="${TOOLCHAIN_TRIPLE}-g++"
-  elif command -v "${TOOLCHAIN_TRIPLE}-clang" >/dev/null 2>&1; then
+  if command -v "${TOOLCHAIN_TRIPLE}-clang" >/dev/null 2>&1; then
     export CC="${TOOLCHAIN_TRIPLE}-clang"
     if command -v "${TOOLCHAIN_TRIPLE}-clang++" >/dev/null 2>&1; then
       export CXX="${TOOLCHAIN_TRIPLE}-clang++"
     else
       export CXX="${TOOLCHAIN_TRIPLE}-clang"
     fi
+  elif command -v "${TOOLCHAIN_TRIPLE}-gcc" >/dev/null 2>&1; then
+    export CC="${TOOLCHAIN_TRIPLE}-gcc"
+    export CXX="${TOOLCHAIN_TRIPLE}-g++"
   else
     echo "❌ Missing Windows x86_64 MinGW cross compiler (${TOOLCHAIN_TRIPLE}-gcc or ${TOOLCHAIN_TRIPLE}-clang)." >&2
     echo "   Install an x86_64 MinGW toolchain or expose it via LLVM_MINGW_ROOT." >&2
@@ -274,6 +274,7 @@ elif [[ "$OUTPUT_DIR" == *mingw_x86_64* ]]; then
   build_common::ensure_mingw_environment "${TOOLCHAIN_TRIPLE}" "${CC:-}"
   export MINGW_TRIPLE="${TOOLCHAIN_TRIPLE}"
 
+  disable_mingw_gcc_avx512_flags=0
   local_mingw_uses_clang=0
   if build_common::compiler_is_clang "${CC:-}"; then
     local_mingw_uses_clang=1
@@ -284,6 +285,22 @@ elif [[ "$OUTPUT_DIR" == *mingw_x86_64* ]]; then
     build_common::append_unique_flag EXTRA_CFLAGS "--target=${TOOLCHAIN_TRIPLE}"
     build_common::append_unique_flag EXTRA_CXXFLAGS "--target=${TOOLCHAIN_TRIPLE}"
     build_common::append_unique_flag EXTRA_CXXFLAGS "-stdlib=libstdc++"
+  else
+    disable_mingw_gcc_avx512_flags=1
+  fi
+
+  if (( disable_mingw_gcc_avx512_flags )); then
+    # GCC 9.2 bundled with Kotlin/Native crashes when processing AVX-512
+    # intrinsics from the Windows headers. Guard against the ICE by disabling
+    # every AVX-512 feature flag and undefining the associated feature macros.
+    for flag in -mno-avx512f -mno-avx512bw -mno-avx512dq -mno-avx512cd -mno-avx512vl; do
+      build_common::append_unique_flag EXTRA_CFLAGS "$flag"
+      build_common::append_unique_flag EXTRA_CXXFLAGS "$flag"
+    done
+    for flag in __AVX512F__ __AVX512BW__ __AVX512DQ__ __AVX512CD__ __AVX512VL__ __AVX512PF__ __AVX512ER__ __AVX512IFMA__ __AVX512VBMI__; do
+      build_common::append_unique_flag EXTRA_CFLAGS "-U${flag}"
+      build_common::append_unique_flag EXTRA_CXXFLAGS "-U${flag}"
+    done
   fi
 
   if (( local_mingw_uses_clang )) && [[ -n "${MINGW_SYSROOT:-}" ]]; then
@@ -317,16 +334,16 @@ elif [[ "$OUTPUT_DIR" == *mingw_x86_64* ]]; then
   fi
 elif [[ "$OUTPUT_DIR" == *mingw_arm64* ]]; then
   TOOLCHAIN_TRIPLE="aarch64-w64-mingw32"
-  if command -v "${TOOLCHAIN_TRIPLE}-gcc" >/dev/null 2>&1; then
-    export CC="${TOOLCHAIN_TRIPLE}-gcc"
-    export CXX="${TOOLCHAIN_TRIPLE}-g++"
-  elif command -v "${TOOLCHAIN_TRIPLE}-clang" >/dev/null 2>&1; then
+  if command -v "${TOOLCHAIN_TRIPLE}-clang" >/dev/null 2>&1; then
     export CC="${TOOLCHAIN_TRIPLE}-clang"
     if command -v "${TOOLCHAIN_TRIPLE}-clang++" >/dev/null 2>&1; then
       export CXX="${TOOLCHAIN_TRIPLE}-clang++"
     else
       export CXX="${TOOLCHAIN_TRIPLE}-clang"
     fi
+  elif command -v "${TOOLCHAIN_TRIPLE}-gcc" >/dev/null 2>&1; then
+    export CC="${TOOLCHAIN_TRIPLE}-gcc"
+    export CXX="${TOOLCHAIN_TRIPLE}-g++"
   else
     echo "❌ Missing Windows ARM64 cross compiler (${TOOLCHAIN_TRIPLE}-gcc or ${TOOLCHAIN_TRIPLE}-clang)." >&2
     echo "   Install an ARM64 MinGW toolchain or expose it via LLVM_MINGW_ROOT." >&2
@@ -336,6 +353,7 @@ elif [[ "$OUTPUT_DIR" == *mingw_arm64* ]]; then
   build_common::ensure_mingw_environment "${TOOLCHAIN_TRIPLE}" "${CC:-}"
   export MINGW_TRIPLE="${TOOLCHAIN_TRIPLE}"
 
+  disable_mingw_gcc_avx512_flags=0
   local_mingw_uses_clang=0
   if build_common::compiler_is_clang "${CC:-}"; then
     local_mingw_uses_clang=1
@@ -346,6 +364,22 @@ elif [[ "$OUTPUT_DIR" == *mingw_arm64* ]]; then
     build_common::append_unique_flag EXTRA_CFLAGS "--target=${TOOLCHAIN_TRIPLE}"
     build_common::append_unique_flag EXTRA_CXXFLAGS "--target=${TOOLCHAIN_TRIPLE}"
     build_common::append_unique_flag EXTRA_CXXFLAGS "-stdlib=libstdc++"
+  else
+    disable_mingw_gcc_avx512_flags=1
+  fi
+
+  if (( disable_mingw_gcc_avx512_flags )); then
+    # GCC 9.2 bundled with Kotlin/Native crashes when processing AVX-512
+    # intrinsics from the Windows headers. Guard against the ICE by disabling
+    # every AVX-512 feature flag and undefining the associated feature macros.
+    for flag in -mno-avx512f -mno-avx512bw -mno-avx512dq -mno-avx512cd -mno-avx512vl; do
+      build_common::append_unique_flag EXTRA_CFLAGS "$flag"
+      build_common::append_unique_flag EXTRA_CXXFLAGS "$flag"
+    done
+    for flag in __AVX512F__ __AVX512BW__ __AVX512DQ__ __AVX512CD__ __AVX512VL__ __AVX512PF__ __AVX512ER__ __AVX512IFMA__ __AVX512VBMI__; do
+      build_common::append_unique_flag EXTRA_CFLAGS "-U${flag}"
+      build_common::append_unique_flag EXTRA_CXXFLAGS "-U${flag}"
+    done
   fi
   if (( local_mingw_uses_clang )) && [[ -n "${MINGW_SYSROOT:-}" ]]; then
     build_common::apply_mingw_sysroot_flags "${TOOLCHAIN_TRIPLE}" EXTRA_CFLAGS EXTRA_CXXFLAGS EXTRA_CMAKEFLAGS

--- a/scripts/setup-konan-llvm-mingw.sh
+++ b/scripts/setup-konan-llvm-mingw.sh
@@ -1,0 +1,304 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+print_usage() {
+  cat <<'USAGE' >&2
+Usage: setup-konan-llvm-mingw.sh [options]
+
+Downloads the JetBrains-packaged llvm-mingw toolchain that ships with the
+Kotlin/Native 2.2.20 release and prints the POSIX path to the extracted
+toolchain directory on stdout.
+
+Options:
+  --toolchains-dir=PATH   Directory where helper repositories and toolchains should be placed.
+  --konan-data-dir=PATH   Directory to use as Kotlin/Native data directory (defaults to <toolchains-dir>/konan-data).
+  --konan-version=VER     Kotlin/Native release version to download (defaults to 2.2.20).
+  --kotlin-release-url=URL
+                          Override the base GitHub release URL (defaults to the
+                          official JetBrains release for the selected version).
+  -h, --help              Show this help message.
+USAGE
+}
+
+log() {
+  printf '[setup-konan] %s\n' "$*" >&2
+}
+
+# Defaults
+TOOLCHAINS_DIR=""
+KONAN_DATA_DIR_OVERRIDE=""
+KONAN_VERSION="2.2.20"
+KOTLIN_RELEASE_URL_OVERRIDE=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --toolchains-dir=*)
+      TOOLCHAINS_DIR="${1#*=}"
+      ;;
+    --konan-data-dir=*)
+      KONAN_DATA_DIR_OVERRIDE="${1#*=}"
+      ;;
+    --konan-version=*)
+      KONAN_VERSION="${1#*=}"
+      ;;
+    --kotlin-release-url=*)
+      KOTLIN_RELEASE_URL_OVERRIDE="${1#*=}"
+      ;;
+    -h|--help)
+      print_usage
+      exit 0
+      ;;
+    *)
+      print_usage
+      log "Unknown option: $1"
+      exit 1
+      ;;
+  esac
+  shift
+done
+
+if [[ -z "$TOOLCHAINS_DIR" ]]; then
+  POSIX_TOOLCHAINS_DIR="$(pwd)/toolchains"
+else
+  POSIX_TOOLCHAINS_DIR="$TOOLCHAINS_DIR"
+fi
+
+if command -v cygpath >/dev/null 2>&1; then
+  POSIX_TOOLCHAINS_DIR="$(cygpath -u "$POSIX_TOOLCHAINS_DIR")"
+fi
+
+if [[ -n "$KONAN_DATA_DIR_OVERRIDE" ]]; then
+  KONAN_DATA_POSIX="$KONAN_DATA_DIR_OVERRIDE"
+  if command -v cygpath >/dev/null 2>&1; then
+    KONAN_DATA_POSIX="$(cygpath -u "$KONAN_DATA_DIR_OVERRIDE")"
+  fi
+else
+  KONAN_DATA_POSIX="$POSIX_TOOLCHAINS_DIR/konan-data"
+fi
+
+if command -v cygpath >/dev/null 2>&1; then
+  KONAN_DATA_ENV="$(cygpath -w "$KONAN_DATA_POSIX")"
+else
+  KONAN_DATA_ENV="$KONAN_DATA_POSIX"
+fi
+
+log "Using toolchains directory: $POSIX_TOOLCHAINS_DIR"
+log "Using Kotlin/Native data directory: $KONAN_DATA_ENV"
+
+if ! command -v curl >/dev/null 2>&1; then
+  log "curl is required but not available in PATH"
+  exit 1
+fi
+
+if ! command -v python >/dev/null 2>&1; then
+  log "python is required but not available in PATH"
+  exit 1
+fi
+
+mkdir -p "$POSIX_TOOLCHAINS_DIR"
+
+# Ensure the Kotlin/Native data directory exists ahead of time so that
+# dependency downloads succeed even if the JVM tooling does not create the
+# directory structure automatically.
+POSIX_KONAN_DATA_DIR_PRESET="$(
+  if command -v cygpath >/dev/null 2>&1; then
+    cygpath -u "$KONAN_DATA_ENV"
+  else
+    printf '%s' "$KONAN_DATA_ENV"
+  fi
+)"
+mkdir -p "$POSIX_KONAN_DATA_DIR_PRESET"
+
+KONAN_ARCHIVE="kotlin-native-prebuilt-windows-x86_64-${KONAN_VERSION}.zip"
+if [[ -n "$KOTLIN_RELEASE_URL_OVERRIDE" ]]; then
+  KONAN_ARCHIVE_URL="$KOTLIN_RELEASE_URL_OVERRIDE"
+else
+  KONAN_ARCHIVE_URL="https://github.com/JetBrains/kotlin/releases/download/v${KONAN_VERSION}/${KONAN_ARCHIVE}"
+fi
+
+KONAN_ARCHIVE_PATH="$POSIX_TOOLCHAINS_DIR/$KONAN_ARCHIVE"
+log "Downloading Kotlin/Native ${KONAN_VERSION} from $KONAN_ARCHIVE_URL"
+curl -fL --retry 5 --retry-delay 2 -o "$KONAN_ARCHIVE_PATH" "$KONAN_ARCHIVE_URL"
+
+KONAN_HOME_DIR="$POSIX_TOOLCHAINS_DIR/${KONAN_ARCHIVE%.zip}"
+if [[ -d "$KONAN_HOME_DIR" ]]; then
+  log "Removing existing Kotlin/Native distribution at $KONAN_HOME_DIR"
+  rm -rf "$KONAN_HOME_DIR"
+fi
+
+log "Extracting $KONAN_ARCHIVE_PATH"
+python - "$KONAN_ARCHIVE_PATH" "$POSIX_TOOLCHAINS_DIR" <<'PY'
+import pathlib
+import sys
+import zipfile
+
+archive = pathlib.Path(sys.argv[1])
+dest = pathlib.Path(sys.argv[2])
+
+with zipfile.ZipFile(archive) as zf:
+    zf.extractall(dest)
+PY
+
+rm -f "$KONAN_ARCHIVE_PATH"
+
+if [[ ! -d "$KONAN_HOME_DIR" ]]; then
+  log "Extracted distribution missing at $KONAN_HOME_DIR"
+  exit 1
+fi
+
+log "Kotlin/Native home: $KONAN_HOME_DIR"
+
+export KONAN_DATA_DIR="$KONAN_DATA_ENV"
+
+UNAME_OUT="$(uname -s 2>/dev/null || echo)"
+case "$UNAME_OUT" in
+  MINGW*|MSYS*|CYGWIN*)
+    STUB_DIR="$(mktemp -d)"
+    trap 'rm -rf "$STUB_DIR"' EXIT
+    STUB_SRC="$STUB_DIR/__setup__.kt"
+    cat <<'EOF' >"$STUB_SRC"
+fun main() = println("kotlin-native setup")
+EOF
+    STUB_OUT="$STUB_DIR/__setup__"
+    if command -v cygpath >/dev/null 2>&1; then
+      WINDOWS_KONAN_HOME="$(cygpath -w "$KONAN_HOME_DIR")"
+      WINDOWS_STUB_SRC="$(cygpath -w "$STUB_SRC")"
+      WINDOWS_STUB_OUT="$(cygpath -w "$STUB_OUT")"
+    else
+      WINDOWS_KONAN_HOME="$KONAN_HOME_DIR"
+      WINDOWS_STUB_SRC="$STUB_SRC"
+      WINDOWS_STUB_OUT="$STUB_OUT"
+    fi
+    WINDOWS_KONAN_DATA="$(cygpath -w "$POSIX_KONAN_DATA_DIR_PRESET")"
+    PREFETCH_SCRIPT="$STUB_DIR/prefetch.bat"
+    if command -v cygpath >/dev/null 2>&1; then
+      WINDOWS_PREFETCH_SCRIPT="$(cygpath -w "$PREFETCH_SCRIPT")"
+    else
+      WINDOWS_PREFETCH_SCRIPT="$PREFETCH_SCRIPT"
+    fi
+    cat <<EOF >"$PREFETCH_SCRIPT"
+@echo off
+setlocal
+set "KONAN_DATA_DIR=${WINDOWS_KONAN_DATA}"
+"${WINDOWS_KONAN_HOME}\\bin\\konanc.bat" -target mingw_x64 -Xkonan-data-dir="${WINDOWS_KONAN_DATA}" -Xcheck-dependencies "${WINDOWS_STUB_SRC}" -o "${WINDOWS_STUB_OUT}"
+exit /b %ERRORLEVEL%
+EOF
+    log "Prefetching mingw_x64 dependencies via konanc"
+    if ! cmd.exe /Q /C "\"${WINDOWS_PREFETCH_SCRIPT}\"" 2>&1 | tr -d '\r' >&2; then
+      log "Warning: konanc failed to prefetch dependencies. Continuing with cached artifacts, if any."
+    fi
+    rm -rf "$STUB_DIR"
+    trap - EXIT
+    ;;
+  *)
+    log "Non-Windows host detected ($UNAME_OUT); skipping konanc dependency prefetch"
+    ;;
+esac
+
+if command -v cygpath >/dev/null 2>&1; then
+  POSIX_KONAN_DATA_DIR="$(cygpath -u "$KONAN_DATA_ENV")"
+else
+  POSIX_KONAN_DATA_DIR="$KONAN_DATA_ENV"
+fi
+
+DEPENDENCIES_HOME="$POSIX_KONAN_DATA_DIR/dependencies"
+mkdir -p "$DEPENDENCIES_HOME"
+
+readarray -t KONAN_PROP_VALUES < <(python - "$KONAN_HOME_DIR/konan/konan.properties" <<'PY'
+import sys
+
+
+def parse_props(path):
+    result = {}
+    with open(path, 'r', encoding='utf-8') as handle:
+        for raw_line in handle:
+            line = raw_line.strip()
+            if not line or line.startswith('#'):
+                continue
+            if '=' not in line:
+                continue
+            key, value = line.split('=', 1)
+            result[key.strip()] = value.strip()
+    return result
+
+
+def emit(value: str) -> None:
+    sys.stdout.buffer.write((value + "\n").encode("utf-8"))
+
+
+props = parse_props(sys.argv[1])
+dependencies_url = props.get('dependenciesUrl', '').rstrip('/')
+toolchain_dependency = props.get('toolchainDependency.mingw_x64', '')
+emit(dependencies_url)
+emit(toolchain_dependency)
+PY
+)
+
+DEPENDENCIES_BASE_URL="${KONAN_PROP_VALUES[0]:-}"
+TOOLCHAIN_DEPENDENCY_NAME="${KONAN_PROP_VALUES[1]:-}"
+
+if [[ -n "$DEPENDENCIES_BASE_URL" && -n "$TOOLCHAIN_DEPENDENCY_NAME" ]]; then
+  TOOLCHAIN_DEPENDENCY_DIR="$DEPENDENCIES_HOME/$TOOLCHAIN_DEPENDENCY_NAME"
+  if [[ ! -d "$TOOLCHAIN_DEPENDENCY_DIR" ]]; then
+    DEP_ARCHIVE="$TOOLCHAIN_DEPENDENCY_NAME.tar.gz"
+    DEP_URL="$DEPENDENCIES_BASE_URL/$DEP_ARCHIVE"
+    TMP_DEP_ARCHIVE="$(mktemp)"
+    log "Downloading Kotlin/Native dependency $TOOLCHAIN_DEPENDENCY_NAME from $DEP_URL"
+    if curl -fL --retry 5 --retry-delay 2 -o "$TMP_DEP_ARCHIVE" "$DEP_URL"; then
+      python - "$TMP_DEP_ARCHIVE" "$DEPENDENCIES_HOME" <<'PY'
+import pathlib
+import sys
+import tarfile
+
+archive = pathlib.Path(sys.argv[1])
+dest = pathlib.Path(sys.argv[2])
+
+with tarfile.open(archive) as tf:
+    tf.extractall(dest)
+PY
+    else
+      log "Warning: unable to download dependency archive from $DEP_URL"
+    fi
+    rm -f "$TMP_DEP_ARCHIVE"
+  fi
+fi
+
+declare -a DEPENDENCY_DIR_CANDIDATES
+DEPENDENCY_DIR_CANDIDATES+=("$DEPENDENCIES_HOME")
+
+DEFAULT_KONAN_DIR="$HOME/.konan/dependencies"
+if [[ -d "$DEFAULT_KONAN_DIR" ]]; then
+  DEPENDENCY_DIR_CANDIDATES+=("$DEFAULT_KONAN_DIR")
+fi
+
+DEPENDENCIES_DIR=""
+for candidate in "${DEPENDENCY_DIR_CANDIDATES[@]}"; do
+  if [[ -d "$candidate" ]]; then
+    DEPENDENCIES_DIR="$candidate"
+    break
+  fi
+done
+
+if [[ -z "$DEPENDENCIES_DIR" ]]; then
+  log "Unable to locate Kotlin/Native dependencies. Checked: ${DEPENDENCY_DIR_CANDIDATES[*]}" >&2
+  exit 1
+fi
+
+if [[ "$DEPENDENCIES_DIR" != "$POSIX_KONAN_DATA_DIR/dependencies" ]]; then
+  log "Using dependencies from alternate location: $DEPENDENCIES_DIR"
+fi
+
+shopt -s nullglob
+mapfile -t TOOLCHAIN_CANDIDATES < <(find "$DEPENDENCIES_DIR" -maxdepth 1 -type d -name 'msys2-mingw-w64-*' | sort)
+shopt -u nullglob
+
+if ((${#TOOLCHAIN_CANDIDATES[@]} == 0)); then
+  log "Unable to locate llvm-mingw toolchain inside $DEPENDENCIES_DIR" >&2
+  exit 1
+fi
+
+LLVM_MINGW_ROOT="${TOOLCHAIN_CANDIDATES[0]}"
+log "Found llvm-mingw toolchain at $LLVM_MINGW_ROOT"
+
+printf '%s\n' "$LLVM_MINGW_ROOT"


### PR DESCRIPTION
## Summary
- expand the MinGW GCC safeguard to disable every AVX-512 feature flag
- explicitly undefine AVX-512 feature macros when GCC is selected for MinGW builds

## Testing
- bash -n buildDependencies.sh

------
https://chatgpt.com/codex/tasks/task_e_68daaf15061883218f1b41338c67ba38