### PR TITLE
Prefer LLVM MinGW sysroot for clang-based MinGW builds

### DIFF
--- a/buildDependencies.sh
+++ b/buildDependencies.sh
@@ -281,6 +281,7 @@ elif [[ "$OUTPUT_DIR" == *mingw_x86_64* ]]; then
     local_mingw_uses_clang=1
   fi
   if (( local_mingw_uses_clang )); then
+    build_common::prefer_llvm_mingw_sysroot "${TOOLCHAIN_TRIPLE}"
     build_common::append_unique_flag EXTRA_CFLAGS "--target=${TOOLCHAIN_TRIPLE}"
     build_common::append_unique_flag EXTRA_CXXFLAGS "--target=${TOOLCHAIN_TRIPLE}"
     build_common::append_unique_flag EXTRA_CXXFLAGS "-stdlib=libstdc++"
@@ -387,6 +388,7 @@ elif [[ "$OUTPUT_DIR" == *mingw_arm64* ]]; then
     local_mingw_uses_clang=1
   fi
   if (( local_mingw_uses_clang )); then
+    build_common::prefer_llvm_mingw_sysroot "${TOOLCHAIN_TRIPLE}"
     build_common::append_unique_flag EXTRA_CFLAGS "--target=${TOOLCHAIN_TRIPLE}"
     build_common::append_unique_flag EXTRA_CXXFLAGS "--target=${TOOLCHAIN_TRIPLE}"
     build_common::append_unique_flag EXTRA_CXXFLAGS "-stdlib=libstdc++"

--- a/buildRocksdbMinGW.sh
+++ b/buildRocksdbMinGW.sh
@@ -107,6 +107,7 @@ if [[ -n "${TOOLCHAIN_TRIPLE:-}" ]]; then
   fi
 
   if (( use_clang )); then
+    build_common::prefer_llvm_mingw_sysroot "${TOOLCHAIN_TRIPLE}"
     build_common::append_unique_flag EXTRA_C_FLAGS "--target=${TOOLCHAIN_TRIPLE}"
     build_common::append_unique_flag EXTRA_CXX_FLAGS "--target=${TOOLCHAIN_TRIPLE}"
     build_common::append_unique_flag EXTRA_CXX_FLAGS "-stdlib=libstdc++"


### PR DESCRIPTION
## Summary
- add a helper that prefers the LLVM MinGW sysroot when a clang-based toolchain is detected
- update the MinGW RocksDB and dependency build scripts to use the LLVM sysroot before applying Windows-specific flags

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68dbefa2f6588321be6c5ba61b487866