### PR TITLE
Update Windows build to LLVM 19 toolchain

### DIFF
--- a/.github/workflows/build-rocksdb.yml
+++ b/.github/workflows/build-rocksdb.yml
@@ -143,7 +143,7 @@ jobs:
       - name: Install LLVM MinGW toolchain
         run: |
           set -euo pipefail
-          LLVM_MINGW_VERSION=20240726
+          LLVM_MINGW_VERSION=20241030
           LLVM_MINGW_DIST="llvm-mingw-${LLVM_MINGW_VERSION}-ucrt-x86_64"
           ARCHIVE_NAME="${LLVM_MINGW_DIST}.zip"
           ARCHIVE_PATH="$PWD/${ARCHIVE_NAME}"
@@ -215,7 +215,7 @@ jobs:
 #      - name: Install LLVM MinGW toolchain
 #        run: |
 #          set -euo pipefail
-#          LLVM_MINGW_VERSION=20250910
+#          LLVM_MINGW_VERSION=20241030
 #          LLVM_MINGW_DIST=llvm-mingw-${LLVM_MINGW_VERSION}-ucrt-x86_64
 #          ARCHIVE_NAME="${LLVM_MINGW_DIST}.zip"
 #          ARCHIVE_PATH="$PWD/${ARCHIVE_NAME}"

--- a/README.md
+++ b/README.md
@@ -41,6 +41,10 @@ The archives are staged under `build/archives/` during a build and can be publis
 - Similarly, simulator builds for iOS, watchOS, and tvOS are arm64-only—aside from the macOS x86_64 build, there are no simulator x86_64 variants because developers are expected to be on Apple Silicon hardware five years after its introduction.
 - The `watchos-arm64` archive labelled above uses the `arm64_32` ABI (64-bit registers with 32-bit pointers) because that remains the deployment baseline for physical watches.
 
+### Windows (MinGW) toolchain baseline
+- Continuous integration provisions [`llvm-mingw-20241030-ucrt-x86_64`](https://github.com/mstorsjo/llvm-mingw/releases/tag/20241030), the first long-lived toolchain built from LLVM 19. `./buildRocksdbMinGW.sh` and `buildDependencies.sh` automatically pick it up when `LLVM_MINGW_ROOT` points at the extracted directory.
+- Kotlin/Native still links MinGW targets with GCC 9.2's libstdc++ runtime, so the workflow also downloads the matching WinLibs sysroot to keep ABI compatibility when consuming the prebuilt archives.
+
 ## Usage examples
 - List available build configurations:
   ```bash
@@ -61,3 +65,8 @@ Before starting a build, ensure the RocksDB submodule is initialized:
 git submodule update --init --recursive
 ```
 This is required because the orchestrator copies headers directly from `rocksdb/include`.
+
+## Troubleshooting
+- [Windows linker diagnostics](docs/windows-linker-diagnostics.md) explains the `comdat section ... without leader and unassociated`
+  messages that `lld-link` may print when the Kotlin/Native toolchain links against the
+  prebuilt MinGW archives.

--- a/docs/windows-linker-diagnostics.md
+++ b/docs/windows-linker-diagnostics.md
@@ -1,0 +1,30 @@
+# Windows linker diagnostics
+
+Kotlin/Native's MinGW targets link applications by invoking LLVM's `lld-link` driver.
+Our CI standardizes on the `llvm-mingw-20241030-ucrt-x86_64` toolchain (LLVM 19), so
+you should expect diagnostics similar to the following during the link step:
+
+```
+ld.lld: comdat section .xdata$_ZNK9__gnu_cxx24__concurrence_lock_error4whatEv without leader and unassociated, discarding
+ld.lld: comdat section .pdata$_ZN7rocksdb9DBOptionsD2Ev without leader and unassociated, discarding
+```
+
+The messages appear while `lld` is scanning `libstdc++.a` (the standard C++ library
+from the MSYS2 GCC 9.2 toolchain bundled with Kotlin/Native) and the `librocksdb.a`
+static library that ships in this repository's Windows archive. The MinGW build
+script compiles RocksDB with the GNU libstdc++ runtime (`-stdlib=libstdc++`), which
+is why `lld` has to inspect that archive as part of the link step.【F:buildRocksdbMinGW.sh†L102-L178】
+
+GCC emits auxiliary `.xdata` and `.pdata` COMDAT sections for exception-handling
+helpers such as the `__gnu_cxx::concurrence_lock_error` types. When the functions are
+optimized away, the associated metadata becomes orphaned. LLVM 19's linker now logs a
+warning as it discards those unreferenced records. The warning does **not** indicate a
+corruption in the RocksDB archive—you can reproduce it with an empty program that only
+links against the same `libstdc++.a` runtime.
+
+Kotlin/Native's driver already passes `-WX:no` to `lld-link`, so these warnings are not
+promoted to errors. If the link ultimately fails, look further down the output for an
+`error:` message that identifies the real cause (for example, a missing symbol or an
+incorrect library search path). Rebuilding RocksDB is only necessary when that final
+error points at unresolved symbols from `librocksdb.a`; otherwise, you can leave the
+prebuilt archive as-is and address the configuration issue that triggered the error.


### PR DESCRIPTION
## Summary
- bump the Windows workflow to provision the llvm-mingw 20241030 toolchain that carries LLVM 19
- document the LLVM 19 MinGW baseline and GCC 9.2 compatibility requirements in the README
- mention the LLVM 19 toolchain in the Windows linker diagnostics guide

## Testing
- not run (CI workflow and documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68dc01457b6c8321babcf6d4c51ecc01