### PR TITLE
Ensure MinGW builds use libstdc++ headers

### DIFF
--- a/buildDependencies.sh
+++ b/buildDependencies.sh
@@ -284,6 +284,7 @@ elif [[ "$OUTPUT_DIR" == *mingw_x86_64* ]]; then
     build_common::append_unique_flag EXTRA_CFLAGS "--target=${TOOLCHAIN_TRIPLE}"
     build_common::append_unique_flag EXTRA_CXXFLAGS "--target=${TOOLCHAIN_TRIPLE}"
     build_common::append_unique_flag EXTRA_CXXFLAGS "-stdlib=libstdc++"
+    export BUILD_COMMON_MINGW_STDLIB="libstdc++"
     build_common::append_unique_flag EXTRA_LDFLAGS "-unwindlib=libgcc"
     if [[ -n "${MINGW_SYSROOT:-}" ]]; then
       mingw_link_dirs=()
@@ -390,6 +391,7 @@ elif [[ "$OUTPUT_DIR" == *mingw_arm64* ]]; then
     build_common::append_unique_flag EXTRA_CFLAGS "--target=${TOOLCHAIN_TRIPLE}"
     build_common::append_unique_flag EXTRA_CXXFLAGS "--target=${TOOLCHAIN_TRIPLE}"
     build_common::append_unique_flag EXTRA_CXXFLAGS "-stdlib=libstdc++"
+    export BUILD_COMMON_MINGW_STDLIB="libstdc++"
     build_common::append_unique_flag EXTRA_LDFLAGS "-unwindlib=libgcc"
     if [[ -n "${MINGW_SYSROOT:-}" ]]; then
       mingw_link_dirs=()

--- a/buildRocksdbMinGW.sh
+++ b/buildRocksdbMinGW.sh
@@ -111,6 +111,7 @@ if [[ -n "${TOOLCHAIN_TRIPLE:-}" ]]; then
     build_common::append_unique_flag EXTRA_C_FLAGS "--target=${TOOLCHAIN_TRIPLE}"
     build_common::append_unique_flag EXTRA_CXX_FLAGS "--target=${TOOLCHAIN_TRIPLE}"
     build_common::append_unique_flag EXTRA_CXX_FLAGS "-stdlib=libstdc++"
+    export BUILD_COMMON_MINGW_STDLIB="libstdc++"
     build_common::append_unique_flag EXTRA_C_FLAGS "-Wno-#warnings"
     build_common::append_unique_flag EXTRA_CXX_FLAGS "-Wno-#warnings"
     build_common::append_unique_flag MINGW_LINK_FLAGS "-unwindlib=libgcc"


### PR DESCRIPTION
## Summary
- export a libstdc++ preference in the MinGW build and dependency scripts when using the LLVM toolchain
- skip injecting libc++ include directories into MinGW builds once libstdc++ is requested

## Testing
- not run (pipeline only)


------
https://chatgpt.com/codex/tasks/task_e_68dc3917af68832187f2c5712c10bab3