### PR TITLE
Switch Windows MinGW build to MSYS2 toolchain

### DIFF
--- a/.github/workflows/build-rocksdb.yml
+++ b/.github/workflows/build-rocksdb.yml
@@ -132,66 +132,25 @@ jobs:
     runs-on: windows-2022
     defaults:
       run:
-        shell: bash
+        shell: msys2 {0}
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: true
-      - name: Install build dependencies
-        run: |
-          choco install -y ninja 7zip
-      - name: Install LLVM MinGW toolchain
-        run: |
-          set -euo pipefail
-          LLVM_MINGW_VERSION=20241030
-          LLVM_MINGW_DIST="llvm-mingw-${LLVM_MINGW_VERSION}-ucrt-x86_64"
-          ARCHIVE_NAME="${LLVM_MINGW_DIST}.zip"
-          ARCHIVE_PATH="$PWD/${ARCHIVE_NAME}"
-          curl --fail --location --silent --show-error \
-            "https://github.com/mstorsjo/llvm-mingw/releases/download/${LLVM_MINGW_VERSION}/${ARCHIVE_NAME}" \
-            --output "$ARCHIVE_PATH"
-          TOOLCHAIN_DIR="$PWD/toolchains"
-          rm -rf "$TOOLCHAIN_DIR/${LLVM_MINGW_DIST}"
-          mkdir -p "$TOOLCHAIN_DIR"
-          7z x "$ARCHIVE_PATH" -o"$TOOLCHAIN_DIR" >/dev/null
-          rm -f "$ARCHIVE_PATH"
-          LLVM_MINGW_ROOT="$TOOLCHAIN_DIR/${LLVM_MINGW_DIST}"
-          echo "LLVM_MINGW_ROOT=${LLVM_MINGW_ROOT//\\/\\\\}" >> "$GITHUB_ENV"
-          echo "${LLVM_MINGW_ROOT//\\/\\\\}/bin" >> "$GITHUB_PATH"
-      - name: Provision GCC 9.x libstdc++ runtime
-        run: |
-          set -euo pipefail
-          GCC9_VERSION=9.5.0
-          WINLIBS_RELEASE="9.5.0-10.0.0-msvcrt-r1"
-          ARCHIVE_NAME="winlibs-x86_64-posix-seh-gcc-${GCC9_VERSION}-mingw-w64msvcrt-10.0.0-r1.zip"
-          ARCHIVE_PATH="$PWD/${ARCHIVE_NAME}"
-          curl --fail --location --silent --show-error \
-            "https://github.com/brechtsanders/winlibs_mingw/releases/download/${WINLIBS_RELEASE}/${ARCHIVE_NAME}" \
-            --output "$ARCHIVE_PATH"
-          GCC9_ROOT="$PWD/toolchains/gcc-${GCC9_VERSION}"
-          rm -rf "$GCC9_ROOT"
-          mkdir -p "$GCC9_ROOT"
-          7z x "$ARCHIVE_PATH" -o"$GCC9_ROOT" >/dev/null
-          rm -f "$ARCHIVE_PATH"
-          if [[ -d "$GCC9_ROOT/mingw64" ]]; then
-            SYSROOT="$GCC9_ROOT/mingw64"
-          else
-            SYSROOT="$(find "$GCC9_ROOT" -maxdepth 2 -type d -name 'mingw64' | head -n 1)"
-          fi
-          if [[ -z "$SYSROOT" ]]; then
-            echo "Failed to locate mingw64 sysroot from GCC 9.x toolchain" >&2
-            exit 1
-          fi
-          SYSROOT="$(cd "$SYSROOT" && pwd)"
-          SYSROOT_PARENT="$(cd "${SYSROOT}/.." 2>/dev/null && pwd 2>/dev/null || true)"
-          if [[ -n "$SYSROOT_PARENT" && "$SYSROOT_PARENT" != "$SYSROOT" ]]; then
-            if [[ -f "${SYSROOT_PARENT}/lib/libgcc_s.a" ]]; then
-              mkdir -p "${SYSROOT}/lib"
-              cp -f "${SYSROOT_PARENT}/lib/libgcc_s.a" "${SYSROOT}/lib/libgcc_s.a"
-            fi
-          fi
-          echo "MINGW_SYSROOT=${SYSROOT//\\/\\\\}" >> "$GITHUB_ENV"
-          echo "MINGW_GCC92_SYSROOT=${SYSROOT//\\/\\\\}" >> "$GITHUB_ENV" # legacy var consumers expect GCC 9.x sysroot here
+      - uses: msys2/setup-msys2@v2
+        with:
+          msystem: MINGW64
+          update: true
+          install: >-
+            git
+            base-devel
+            mingw-w64-x86_64-toolchain
+            mingw-w64-x86_64-cmake
+            mingw-w64-x86_64-ninja
+            mingw-w64-x86_64-python
+            mingw-w64-x86_64-curl
+            mingw-w64-x86_64-zip
+            mingw-w64-x86_64-unzip
       - name: Build Windows MinGW package
         run: ./build.sh mingwX64
       - uses: actions/upload-artifact@v4

--- a/README.md
+++ b/README.md
@@ -42,8 +42,8 @@ The archives are staged under `build/archives/` during a build and can be publis
 - The `watchos-arm64` archive labelled above uses the `arm64_32` ABI (64-bit registers with 32-bit pointers) because that remains the deployment baseline for physical watches.
 
 ### Windows (MinGW) toolchain baseline
-- Continuous integration provisions [`llvm-mingw-20241030-ucrt-x86_64`](https://github.com/mstorsjo/llvm-mingw/releases/tag/20241030), the first long-lived toolchain built from LLVM 19. `./buildRocksdbMinGW.sh` and `buildDependencies.sh` automatically pick it up when `LLVM_MINGW_ROOT` points at the extracted directory.
-- Kotlin/Native still links MinGW targets with GCC 9.2's libstdc++ runtime, so the workflow also downloads the matching WinLibs sysroot to keep ABI compatibility when consuming the prebuilt archives.
+- Continuous integration now provisions an MSYS2 MinGW-w64 environment (via [`msys2/setup-msys2`](https://github.com/msys2/setup-msys2)) and installs the `mingw-w64-x86_64-toolchain`, `mingw-w64-x86_64-cmake`, and `mingw-w64-x86_64-ninja` packages. This supplies GCC/Clang frontends, the MinGW sysroot, and build utilities directly from the MSYS2 distribution.
+- RocksDB is compiled with `-O3 -DNDEBUG -fexceptions -frtti -fno-omit-frame-pointer` and the Windows portability defines (`WIN32_LEAN_AND_MEAN`, `UNICODE`, `_UNICODE`, `PORTABLE=1`). Link flags request static libstdc++/libgcc to keep the produced `.a` archives self-contained when linked from Kotlin/Native or other consumers.
 
 ## Usage examples
 - List available build configurations:

--- a/buildRocksdbMinGW.sh
+++ b/buildRocksdbMinGW.sh
@@ -95,6 +95,21 @@ esac
 build_common::append_unique_flag EXTRA_C_FLAGS "-fno-emulated-tls"
 build_common::append_unique_flag EXTRA_CXX_FLAGS "-fno-emulated-tls"
 
+for optimization_flag in -O3 -DNDEBUG -fexceptions -fno-omit-frame-pointer; do
+  build_common::append_unique_flag EXTRA_C_FLAGS "$optimization_flag"
+  build_common::append_unique_flag EXTRA_CXX_FLAGS "$optimization_flag"
+done
+
+for define_flag in -DWIN32_LEAN_AND_MEAN -DUNICODE -D_UNICODE; do
+  build_common::append_unique_flag EXTRA_C_FLAGS "$define_flag"
+  build_common::append_unique_flag EXTRA_CXX_FLAGS "$define_flag"
+done
+
+build_common::append_unique_flag EXTRA_CXX_FLAGS "-frtti"
+
+build_common::append_unique_flag MINGW_LINK_FLAGS "-static-libstdc++"
+build_common::append_unique_flag MINGW_LINK_FLAGS "-static-libgcc"
+
 if [[ -n "${TOOLCHAIN_TRIPLE:-}" ]]; then
   build_common::ensure_mingw_environment "${TOOLCHAIN_TRIPLE}" "${CC:-}"
   export MINGW_TRIPLE="${TOOLCHAIN_TRIPLE}"


### PR DESCRIPTION
## Summary
- replace the GitHub Actions Windows MinGW job with an MSYS2-based environment so the GCC toolchain and build utilities come from MSYS2 packages
- add explicit Windows optimization, exception handling, RTTI, and static runtime flags when building RocksDB for MinGW
- document the new MSYS2 toolchain baseline and enforced flags in the README

## Testing
- ./build.sh --list

------
https://chatgpt.com/codex/tasks/task_e_68dc44c9dcac83218d0b8074c3305e03