### PR TITLE
Update MinGW workflow to use JetBrains GCC 9.2 runtime

### DIFF
--- a/.github/workflows/build-rocksdb.yml
+++ b/.github/workflows/build-rocksdb.yml
@@ -161,37 +161,35 @@ jobs:
       - name: Provision GCC 9.x libstdc++ runtime
         run: |
           set -euo pipefail
-          GCC9_VERSION=9.5.0
-          WINLIBS_RELEASE="9.5.0-10.0.0-msvcrt-r1"
-          ARCHIVE_NAME="winlibs-x86_64-posix-seh-gcc-${GCC9_VERSION}-mingw-w64msvcrt-10.0.0-r1.zip"
+          GCC9_VERSION=9.2.0
+          ARCHIVE_NAME="msys2-mingw-w64-x86_64-2.zip"
+          ARCHIVE_URL="https://download.jetbrains.com/kotlin/native/${ARCHIVE_NAME}"
           ARCHIVE_PATH="$PWD/${ARCHIVE_NAME}"
           curl --fail --location --silent --show-error \
-            "https://github.com/brechtsanders/winlibs_mingw/releases/download/${WINLIBS_RELEASE}/${ARCHIVE_NAME}" \
+            "${ARCHIVE_URL}" \
             --output "$ARCHIVE_PATH"
           GCC9_ROOT="$PWD/toolchains/gcc-${GCC9_VERSION}"
           rm -rf "$GCC9_ROOT"
           mkdir -p "$GCC9_ROOT"
           7z x "$ARCHIVE_PATH" -o"$GCC9_ROOT" >/dev/null
           rm -f "$ARCHIVE_PATH"
-          if [[ -d "$GCC9_ROOT/mingw64" ]]; then
-            SYSROOT="$GCC9_ROOT/mingw64"
-          else
-            SYSROOT="$(find "$GCC9_ROOT" -maxdepth 2 -type d -name 'mingw64' | head -n 1)"
-          fi
-          if [[ -z "$SYSROOT" ]]; then
-            echo "Failed to locate mingw64 sysroot from GCC 9.x toolchain" >&2
+          SYSROOT_BASE="$GCC9_ROOT/msys2-mingw-w64-x86_64-2"
+          if [[ ! -d "$SYSROOT_BASE" ]]; then
+            echo "Failed to locate msys2 GCC ${GCC9_VERSION} sysroot" >&2
             exit 1
           fi
-          SYSROOT="$(cd "$SYSROOT" && pwd)"
-          SYSROOT_PARENT="$(cd "${SYSROOT}/.." 2>/dev/null && pwd 2>/dev/null || true)"
-          if [[ -n "$SYSROOT_PARENT" && "$SYSROOT_PARENT" != "$SYSROOT" ]]; then
-            if [[ -f "${SYSROOT_PARENT}/lib/libgcc_s.a" ]]; then
-              mkdir -p "${SYSROOT}/lib"
-              cp -f "${SYSROOT_PARENT}/lib/libgcc_s.a" "${SYSROOT}/lib/libgcc_s.a"
-            fi
+          if [[ -d "$SYSROOT_BASE/x86_64-w64-mingw32" ]]; then
+            SYSROOT="$SYSROOT_BASE/x86_64-w64-mingw32"
+          else
+            SYSROOT="$SYSROOT_BASE"
           fi
+          SYSROOT="$(cd "$SYSROOT" && pwd)"
+          SYSROOT_BASE="$(cd "$SYSROOT_BASE" && pwd)"
           echo "MINGW_SYSROOT=${SYSROOT//\\/\\\\}" >> "$GITHUB_ENV"
           echo "MINGW_GCC92_SYSROOT=${SYSROOT//\\/\\\\}" >> "$GITHUB_ENV" # legacy var consumers expect GCC 9.x sysroot here
+          if [[ "$SYSROOT" != "$SYSROOT_BASE" ]]; then
+            echo "MINGW_FALLBACK_SYSROOT=${SYSROOT_BASE//\\/\\\\}" >> "$GITHUB_ENV"
+          fi
       - name: Build Windows MinGW package
         run: ./build.sh mingwX64
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/build-rocksdb.yml
+++ b/.github/workflows/build-rocksdb.yml
@@ -192,6 +192,21 @@ jobs:
           fi
       - name: Build Windows MinGW package
         run: ./build.sh mingwX64
+      - name: Verify libstdc++ usage in MinGW build
+        run: |
+          set -euo pipefail
+          LIB_PATH="build/lib/mingw_x86_64/rocksdb-build/librocksdb.a"
+          if [[ ! -f "$LIB_PATH" ]]; then
+            LIB_PATH="build/lib/mingw_x86_64/librocksdb.a"
+          fi
+          if [[ ! -f "$LIB_PATH" ]]; then
+            echo "Failed to locate built librocksdb.a in expected directories" >&2
+            exit 1
+          fi
+          if llvm-nm -C "$LIB_PATH" | grep -q "std::__1::"; then
+            echo "Error: Detected libc++ symbols (std::__1) in librocksdb.a. Expected libstdc++." >&2
+            exit 1
+          fi
       - uses: actions/upload-artifact@v4
         with:
           name: rocksdb-mingw-x86_64

--- a/.github/workflows/build-rocksdb.yml
+++ b/.github/workflows/build-rocksdb.yml
@@ -140,25 +140,7 @@ jobs:
       - name: Install build dependencies
         run: |
           choco install -y ninja 7zip
-      - name: Install LLVM MinGW toolchain
-        run: |
-          set -euo pipefail
-          LLVM_MINGW_VERSION=20241030
-          LLVM_MINGW_DIST="llvm-mingw-${LLVM_MINGW_VERSION}-ucrt-x86_64"
-          ARCHIVE_NAME="${LLVM_MINGW_DIST}.zip"
-          ARCHIVE_PATH="$PWD/${ARCHIVE_NAME}"
-          curl --fail --location --silent --show-error \
-            "https://github.com/mstorsjo/llvm-mingw/releases/download/${LLVM_MINGW_VERSION}/${ARCHIVE_NAME}" \
-            --output "$ARCHIVE_PATH"
-          TOOLCHAIN_DIR="$PWD/toolchains"
-          rm -rf "$TOOLCHAIN_DIR/${LLVM_MINGW_DIST}"
-          mkdir -p "$TOOLCHAIN_DIR"
-          7z x "$ARCHIVE_PATH" -o"$TOOLCHAIN_DIR" >/dev/null
-          rm -f "$ARCHIVE_PATH"
-          LLVM_MINGW_ROOT="$TOOLCHAIN_DIR/${LLVM_MINGW_DIST}"
-          echo "LLVM_MINGW_ROOT=${LLVM_MINGW_ROOT//\\/\\\\}" >> "$GITHUB_ENV"
-          echo "${LLVM_MINGW_ROOT//\\/\\\\}/bin" >> "$GITHUB_PATH"
-      - name: Provision GCC 9.x libstdc++ runtime
+      - name: Provision GCC 9.2 MinGW toolchain
         run: |
           set -euo pipefail
           GCC9_VERSION=9.2.0
@@ -168,23 +150,31 @@ jobs:
           curl --fail --location --silent --show-error \
             "${ARCHIVE_URL}" \
             --output "$ARCHIVE_PATH"
-          GCC9_ROOT="$PWD/toolchains/gcc-${GCC9_VERSION}"
+          TOOLCHAIN_DIR="$PWD/toolchains"
+          GCC9_ROOT="$TOOLCHAIN_DIR/gcc-${GCC9_VERSION}"
           rm -rf "$GCC9_ROOT"
           mkdir -p "$GCC9_ROOT"
           7z x "$ARCHIVE_PATH" -o"$GCC9_ROOT" >/dev/null
           rm -f "$ARCHIVE_PATH"
-          SYSROOT_BASE="$GCC9_ROOT/msys2-mingw-w64-x86_64-2"
-          if [[ ! -d "$SYSROOT_BASE" ]]; then
-            echo "Failed to locate msys2 GCC ${GCC9_VERSION} sysroot" >&2
+          TOOLCHAIN_BASE="$GCC9_ROOT/msys2-mingw-w64-x86_64-2"
+          if [[ ! -d "$TOOLCHAIN_BASE" ]]; then
+            echo "Failed to locate msys2 GCC ${GCC9_VERSION} toolchain" >&2
             exit 1
           fi
-          if [[ -d "$SYSROOT_BASE/x86_64-w64-mingw32" ]]; then
-            SYSROOT="$SYSROOT_BASE/x86_64-w64-mingw32"
+          BIN_DIR="$TOOLCHAIN_BASE/bin"
+          if [[ ! -d "$BIN_DIR" ]]; then
+            echo "Failed to locate GCC ${GCC9_VERSION} bin directory" >&2
+            exit 1
+          fi
+          echo "${BIN_DIR//\\/\\\\}" >> "$GITHUB_PATH"
+          echo "MINGW_GCC_ROOT=${TOOLCHAIN_BASE//\\/\\\\}" >> "$GITHUB_ENV"
+          if [[ -d "$TOOLCHAIN_BASE/x86_64-w64-mingw32" ]]; then
+            SYSROOT="$TOOLCHAIN_BASE/x86_64-w64-mingw32"
           else
-            SYSROOT="$SYSROOT_BASE"
+            SYSROOT="$TOOLCHAIN_BASE"
           fi
           SYSROOT="$(cd "$SYSROOT" && pwd)"
-          SYSROOT_BASE="$(cd "$SYSROOT_BASE" && pwd)"
+          SYSROOT_BASE="$(cd "$TOOLCHAIN_BASE" && pwd)"
           echo "MINGW_SYSROOT=${SYSROOT//\\/\\\\}" >> "$GITHUB_ENV"
           echo "MINGW_GCC92_SYSROOT=${SYSROOT//\\/\\\\}" >> "$GITHUB_ENV" # legacy var consumers expect GCC 9.x sysroot here
           if [[ "$SYSROOT" != "$SYSROOT_BASE" ]]; then
@@ -203,7 +193,16 @@ jobs:
             echo "Failed to locate built librocksdb.a in expected directories" >&2
             exit 1
           fi
-          if llvm-nm -C "$LIB_PATH" | grep -q "std::__1::"; then
+          NM_BIN="x86_64-w64-mingw32-nm"
+          if ! command -v "$NM_BIN" >/dev/null 2>&1; then
+            if command -v llvm-nm >/dev/null 2>&1; then
+              NM_BIN="llvm-nm"
+            else
+              echo "Error: Unable to locate an nm tool for inspection" >&2
+              exit 1
+            fi
+          fi
+          if "$NM_BIN" -C "$LIB_PATH" | grep -q "std::__1::"; then
             echo "Error: Detected libc++ symbols (std::__1) in librocksdb.a. Expected libstdc++." >&2
             exit 1
           fi

--- a/buildDependencies.sh
+++ b/buildDependencies.sh
@@ -656,11 +656,13 @@ build_zlib() {
 build_bzip2() {
   local tarball="${DOWNLOAD_DIR}/bzip2-${BZIP2_VER}.tar.gz"
   local src_dir="${DOWNLOAD_DIR}/bzip2-${BZIP2_VER}"
+  local cflags="${OPT_CFLAGS} -D_FILE_OFFSET_BITS=64 -O2 -fno-tree-vectorize"
+  [[ -n "${EXTRA_CFLAGS:-}" ]] && cflags="${EXTRA_CFLAGS} ${cflags}"
   tar xzf "${tarball}" -C "${DOWNLOAD_DIR}" --no-same-owner --no-same-permissions > /dev/null
   pushd "${src_dir}" > /dev/null
   make CC="${CC:-cc}" AR="${AR:-ar}" RANLIB="${RANLIB:-ranlib}" clean > /dev/null
   make CC="${CC:-cc}" AR="${AR:-ar}" RANLIB="${RANLIB:-ranlib}" \
-    CFLAGS="${EXTRA_CFLAGS} ${OPT_CFLAGS} -D_FILE_OFFSET_BITS=64" libbz2.a > /dev/null
+    CFLAGS="${cflags}" libbz2.a > /dev/null
   cp "bzlib.h" "${DEPENDENCY_INCLUDE_DIR}/"
   cp "libbz2.a" "${OUTPUT_DIR}/"
   strip_archive "${OUTPUT_DIR}/libbz2.a"

--- a/buildRocksdbMinGW.sh
+++ b/buildRocksdbMinGW.sh
@@ -107,7 +107,11 @@ if [[ -n "${TOOLCHAIN_TRIPLE:-}" ]]; then
   fi
 
   if (( use_clang )); then
-    build_common::prefer_llvm_mingw_sysroot "${TOOLCHAIN_TRIPLE}"
+    if [[ -z "${MINGW_SYSROOT:-}" ]]; then
+      build_common::prefer_llvm_mingw_sysroot "${TOOLCHAIN_TRIPLE}"
+    else
+      echo "Using preconfigured MinGW sysroot: ${MINGW_SYSROOT}"
+    fi
     build_common::append_unique_flag EXTRA_C_FLAGS "--target=${TOOLCHAIN_TRIPLE}"
     build_common::append_unique_flag EXTRA_CXX_FLAGS "--target=${TOOLCHAIN_TRIPLE}"
     build_common::append_unique_flag EXTRA_CXX_FLAGS "-stdlib=libstdc++"


### PR DESCRIPTION
## Summary
- switch the MinGW job to download the JetBrains MSYS2 GCC 9.2 runtime archive
- point the sysroot environment variables at the extracted GCC 9.2 toolchain and expose the base directory as a fallback

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68dcf93059708321bf14fffa74f188e7