### PR TITLE
Enable emulated TLS for MinGW builds

### DIFF
--- a/buildRocksdbMinGW.sh
+++ b/buildRocksdbMinGW.sh
@@ -122,8 +122,8 @@ if [[ -n "${TOOLCHAIN_TRIPLE:-}" ]]; then
   fi
 
   if (( use_clang )); then
-    build_common::append_unique_flag EXTRA_C_FLAGS "-fno-emulated-tls"
-    build_common::append_unique_flag EXTRA_CXX_FLAGS "-fno-emulated-tls"
+    build_common::append_unique_flag EXTRA_C_FLAGS "-femulated-tls"
+    build_common::append_unique_flag EXTRA_CXX_FLAGS "-femulated-tls"
     if [[ -z "${MINGW_SYSROOT:-}" ]]; then
       build_common::prefer_llvm_mingw_sysroot "${TOOLCHAIN_TRIPLE}"
     else


### PR DESCRIPTION
## Summary
- switch MinGW clang builds to use -femulated-tls instead of disabling emulated TLS

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de0b659d9c8321ba84ac8e6f05ae4c